### PR TITLE
Preload provides sizes on Android

### DIFF
--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -79,10 +79,7 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
 
                                     final int w = drawable.getIntrinsicWidth();
                                     final int h = drawable.getIntrinsicHeight();
-
                                     final WritableMap map = new WritableNativeMap();
-                                    Log.i("RNFI", "Here's the width: " + w);
-                                    Log.i("RNFI", "Here's the height: " + h);
 
                                     map.putInt("width", w);
                                     map.putInt("height", h);

--- a/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
+++ b/android/src/main/java/com/dylanvann/fastimage/FastImageViewModule.java
@@ -2,6 +2,7 @@ package com.dylanvann.fastimage;
 
 import android.app.Activity;
 import android.graphics.drawable.Drawable;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
@@ -74,22 +75,22 @@ class FastImageViewModule extends ReactContextBaseJavaModule {
 
                                 @Override
                                 public boolean onResourceReady(Drawable drawable, Object o, Target<Drawable> target, DataSource dataSource, boolean b) {
+                                    if (!canIssuePromise) return false;
+
+                                    final int w = drawable.getIntrinsicWidth();
+                                    final int h = drawable.getIntrinsicHeight();
+
+                                    final WritableMap map = new WritableNativeMap();
+                                    Log.i("RNFI", "Here's the width: " + w);
+                                    Log.i("RNFI", "Here's the height: " + h);
+
+                                    map.putInt("width", w);
+                                    map.putInt("height", h);
+                                    onSizeDetermined.resolve(map);
                                     return false;
                                 }
                             })
                             .preload();
-
-                    if (canIssuePromise) {
-                        target.getSize(new SizeReadyCallback() {
-                            @Override
-                            public void onSizeReady(int w, int h) {
-                                final WritableMap map = new WritableNativeMap();
-                                map.putInt("width", w);
-                                map.putInt("height", h);
-                                onSizeDetermined.resolve(map);
-                            }
-                        });
-                    }
                 }
             }
         });

--- a/ios/FastImage/FFFastImageViewManager.m
+++ b/ios/FastImage/FFFastImageViewManager.m
@@ -21,7 +21,8 @@ RCT_EXPORT_VIEW_PROPERTY(onFastImageLoad, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onFastImageLoadEnd, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(tintColor, imageColor, UIColor)
 
-RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
+RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources resolver:(RCTPromiseResolveBlock)resolve
+    rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSMutableArray *urls = [NSMutableArray arrayWithCapacity:sources.count];
 
@@ -33,6 +34,7 @@ RCT_EXPORT_METHOD(preload:(nonnull NSArray<FFFastImageSource *> *)sources)
     }];
 
     [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:urls];
+    resolve(NULL);
 }
 
 RCT_EXPORT_METHOD(clearMemoryCache:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -202,9 +202,11 @@ export interface FastImageStaticProperties {
     resizeMode: typeof resizeMode
     priority: typeof priority
     cacheControl: typeof cacheControl
-    preload: (sources: Source[]) => void
     clearMemoryCache: () => Promise<void>
     clearDiskCache: () => Promise<void>
+    preload: (
+        sources: Source[],
+    ) => Promise<{ width: number; height: number } | null>
 }
 
 const FastImage: React.ComponentType<FastImageProps> &


### PR DESCRIPTION
Make Preload return image width/height on Android. On iOS this sadly isn't possible because we don't get any information about the image at preload time other than the number that succeeded